### PR TITLE
feat: explicitly specify devDependency on @cdktf/provider-project

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -6,6 +6,7 @@ const project = new CdktfProviderProject({
   constructsVersion: "^10.0.0",
   minNodeVersion: "14.17.0",
   jsiiVersion: "^1.53.0",
+  devDeps: ["@cdktf/provider-project@^0.2.95"],
 });
 
 // This is a temporary workaround since the API.md file is growing too large


### PR DESCRIPTION
as the next version of @cdktf/provider-project will stop specifying the devDep itself and start using those that were passed to it
